### PR TITLE
Conditionally build and push multi-arch Docker image

### DIFF
--- a/.github/workflows/build_docker_multi_arch.yml
+++ b/.github/workflows/build_docker_multi_arch.yml
@@ -5,11 +5,14 @@ on:
     branches:
       - main
       - master
+      - '*'   # remove it when ready
+      - '**'  # remove it when ready
     tags:
       - '*.*.*'
 
 jobs:
-  docker:
+  build_docker_image:
+    name: Build multi-arch Docker image
     runs-on: ubuntu-latest
     steps:
     -

--- a/.github/workflows/build_docker_multi_arch.yml
+++ b/.github/workflows/build_docker_multi_arch.yml
@@ -11,14 +11,37 @@ on:
       - '*.*.*'
 
 jobs:
+  check_secrets:
+    name: Check whether repository secrets are set
+    runs-on: ubuntu-latest
+    outputs:
+      DOCKERHUB_USERNAME: ${{ steps.dockerhub_username.outputs.is_set }}
+      DOCKERHUB_TOKEN: ${{ steps.dockerhub_token.outputs.is_set }}
+      ALL: ${{ steps.dockerhub_token.outputs.is_set && steps.dockerhub_token.outputs.is_set }}
+    steps:
+    -
+      name: Check DOCKERHUB_USERNAME
+      id: dockerhub_username
+      run: |
+        echo "is_set: ${{ secrets.DOCKERHUB_USERNAME != '' }}"
+        echo "::set-output name=is_set::${{ secrets.DOCKERHUB_USERNAME != '' }}"
+    -
+      name: Check DOCKERHUB_TOKEN
+      id: dockerhub_token
+      run: |
+        echo "is_set: ${{ secrets.DOCKERHUB_TOKEN != '' }}"
+        echo "::set-output name=is_set::${{ secrets.DOCKERHUB_TOKEN != '' }}"
   build_docker_image:
     name: Build multi-arch Docker image
     runs-on: ubuntu-latest
+    needs:
+    - check_secrets
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
     -
+      if: ${{ needs.check_secrets.outputs.ALL == 'true' }}
       name: Docker meta
       id: docker_meta
       uses: crazy-max/ghaction-docker-meta@v2.2.1
@@ -32,8 +55,8 @@ jobs:
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     -
+      if: ${{ github.event_name != 'pull_request' && needs.check_secrets.outputs.ALL == 'true' }}
       name: Login to DockerHub
-      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -46,6 +69,6 @@ jobs:
         platforms: |
           linux/amd64
           linux/arm64/v8
-        push: ${{ github.event_name != 'pull_request' }}
+        push: ${{ github.event_name != 'pull_request' && needs.check_secrets.outputs.ALL == 'true' }}
         tags: ${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/build_docker_multi_arch.yml
+++ b/.github/workflows/build_docker_multi_arch.yml
@@ -41,7 +41,7 @@ jobs:
       name: Checkout
       uses: actions/checkout@v2
     -
-      if: ${{ needs.check_secrets.outputs.ALL == 'true' }}
+      if: ${{ needs.check_secrets.outputs.DOCKERHUB_USERNAME == 'true' }}
       name: Docker meta
       id: docker_meta
       uses: crazy-max/ghaction-docker-meta@v2.2.1

--- a/.github/workflows/build_docker_multi_arch.yml
+++ b/.github/workflows/build_docker_multi_arch.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - master
-      - '*'   # remove it when ready
-      - '**'  # remove it when ready
     tags:
       - '*.*.*'
 


### PR DESCRIPTION
**Scope of the pull request**

Build and push the multi-arch Docker image only if repository secrets `DOCKERHUB_USER` and `DOCKERHUB_TOKEN` are set.

**Solved issues**

None

**Added issues**

None

**Tests**

- [x] I manually tested
- [ ] I added unit test
- [ ] I ran the existing unit test and they do not fail
