### PR TITLE
Add workflow to publish on PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,67 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types:
+    - published
+
+jobs:
+  check_secrets:
+    name: Check secrets
+    runs-on: ubuntu-latest
+    outputs:
+      ALL: ${{ steps.pypi_api_token.outputs.is_set && steps.test_pypi_api_token.outputs.is_set }}
+      PYPI_API_TOKEN: ${{ steps.pypi_api_token.outputs.is_set }}
+      TEST_PYPI_API_TOKEN: ${{ steps.test_pypi_api_token.outputs.is_set }}
+    steps:
+    -
+      name: Check PYPI_API_TOKEN
+      id: pypi_api_token
+      run: |
+        echo "is_set: ${{ secrets.PYPI_API_TOKEN != '' }}"
+        echo "::set-output name=is_set::${{ secrets.PYPI_API_TOKEN != '' }}"
+    -
+      name: Check TEST_PYPI_API_TOKEN
+      id: test_pypi_api_token
+      run: |
+        echo "is_set: ${{ secrets.TEST_PYPI_API_TOKEN != '' }}"
+        echo "::set-output name=is_set::${{ secrets.TEST_PYPI_API_TOKEN != '' }}"
+  build_and_publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    needs:
+    - check_secrets
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+    -
+      name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
+    -
+      name: Install pypa/build
+      run: python -m pip install build --user
+    -
+      name: Build binary wheel and source tarball
+      working-directory: ./python
+      run: python -m build --sdist --wheel --outdir dist/
+    -
+      if: ${{ needs.check_secrets.outputs.TEST_PYPI_API_TOKEN == 'true' && github.event.release.prerelease }}
+      name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages_dir: ./python/dist/
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        verbose: true
+    -
+      if: ${{ needs.check_secrets.outputs.PYPI_API_TOKEN == 'true' && !github.event.release.prerelease }}
+      name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages_dir: ./python/dist/
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish to PyPI and TestPyPI
 
 on:
   release:
@@ -50,7 +50,7 @@ jobs:
       run: python -m build --sdist --wheel --outdir dist/
     -
       if: ${{ needs.check_secrets.outputs.TEST_PYPI_API_TOKEN == 'true' && github.event.release.prerelease }}
-      name: Publish to Test PyPI
+      name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages_dir: ./python/dist/

--- a/python/setup.py
+++ b/python/setup.py
@@ -38,6 +38,13 @@ def get_requirements():
     return requirements
 
 
+def long_description():
+    with open('README.md', 'r') as fp:
+        lines = fp.readlines()
+        fp.close()
+    return ''.join(lines)
+
+
 setup(
     name='spid_compliant_certificates',
     version=version,
@@ -45,6 +52,8 @@ setup(
     author='Paolo Smiraglia',
     author_email='paolo.smiraglia@gmail.com',
     description='Generate X509 certificates according to Avviso SPID 29 v3',
+    long_description=long_description(),
+    long_description_content_type='text/markdown',
     license='MIT',
     url='https://github.com/italia/spid-compliant-certificates',
 

--- a/python/spid_compliant_certificates/__init__.py
+++ b/python/spid_compliant_certificates/__init__.py
@@ -20,7 +20,7 @@
 
 # (major, minor, patch, level, serial)
 # levels: alpha, beta, rc, final
-version_info = (0, 1, 0, 'rc', 0)
+version_info = (0, 1, 0, 'alpha', 0)
 
 
 def _version() -> str:


### PR DESCRIPTION
**Scope of the pull request**

The PR adds a workflow to publish on [PyPI](https://pypi.org/) when a new release is published. In case of pre-release, the publishing occurs on [TestPyPI](https://test.pypi.org/). The workflow requires the definition of `TEST_PYPI_API_TOKEN` and `PYPI_API_TOKEN` secrets.

**Solved issues**

None

**Added issues**

None

**Tests**

- [x] I manually tested
- [ ] I added unit test
- [ ] I ran the existing unit test and they do not fail
