### PR TITLE
Fix dependencies for package build and installation

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -42,12 +42,11 @@ jobs:
         python-version: 3.8
         architecture: x64
     -
-      name: Install pypa/build
-      run: python -m pip install build --user
-    -
       name: Build binary wheel and source tarball
       working-directory: ./python
-      run: python -m build --sdist --wheel --outdir dist/
+      run: |
+        python -m pip install wheel packaging
+        python setup.py sdist bdist_wheel
     -
       if: ${{ needs.check_secrets.outputs.TEST_PYPI_API_TOKEN == 'true' && github.event.release.prerelease }}
       name: Publish to TestPyPI

--- a/python/.hadolint.yaml
+++ b/python/.hadolint.yaml
@@ -1,2 +1,1 @@
 ignored:
-- DL3029  # https://github.com/hadolint/hadolint/wiki/DL3029

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -18,10 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM --platform=$BUILDPLATFORM python:3-slim
-
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
+FROM python:3-slim
 
 LABEL maintainer="Paolo Smiraglia <paolo.smiraglia@gmail.com>"
 
@@ -30,8 +27,10 @@ WORKDIR /src/app
 
 RUN useradd --no-create-home spid \
     && mkdir /tmp/certs \
+    && chown -R spid /tmp/certs \
     && ln -s /tmp/certs /certs \
-    && pip install --no-cache-dir .
+    && pip install --no-cache-dir -r requirements.txt \
+    && python setup.py install
 
 WORKDIR /certs
 RUN rm -fr /src/app

--- a/python/README.md
+++ b/python/README.md
@@ -7,7 +7,12 @@ to Avviso SPID n.29 v3.
 
 Nothing more than
 
-    $ pip install .
+    $ pip install spid-compliant-certificates
+
+Alternatively, you can install it from sources
+
+    $ pip install -r requirements.txt
+    $ python setup.py install
 
 ## Command line usage
 


### PR DESCRIPTION
**Scope of the pull request**

With #38, the version of the package is computed by relying on `pypa/packaging`. This implies that such a package must be installed before installing/building `spid-compliant-certificates`. The current PR implements it within the `Dockerfile` as well as in `pypi` workflow. It is also documented within the readme file.

**Solved issues**

None

**Added issues**

None

**Tests**

- [x] I manually tested
- [ ] I added unit test
- [ ] I ran the existing unit test and they do not fail
